### PR TITLE
Refactored merge rule using the script directive.

### DIFF
--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -76,12 +76,10 @@ rule merge_pe_reads:
     log:
         "logs/merge/{unit}.log"
     params:
-        padding_quality='H',
+        join_quality='H',
         join_seq=config["reads"]["join_seq"]
-    shell:
-        "python ../scripts/merge_mates.py {input.fq1}  {input.fq2} "
-        "{output.merged} --padding-quality {params.padding_quality} "
-        "--padding-bases {params.join_seq} > {log}"
+    script:
+        "../scripts/merge_mates.py"
 
 
 rule extract:

--- a/scripts/merge_mates.py
+++ b/scripts/merge_mates.py
@@ -1,42 +1,40 @@
+"""Merge the p5 and p7 reads from the input files into one read,
+joined by join bases.
+"""
 import sys
 import click
 import dinopy
 
+# redirect stderr to logfile
+sys.stderr = open(snakemake.log[0], "w")
 
-@click.command(short_help="later")
-@click.argument("p5_file", nargs=1, type=click.Path(exists=True))
-@click.argument("p7_file", nargs=1, type=click.Path(exists=True))
-@click.argument("merged_file", nargs=1, type=click.Path(dir_okay=True))
-@click.option("--padding-bases", "padding_bases", default=b"NNNNN")
-@click.option("--padding-quality", "padding_quality", default=b"!")
-def merge_mates(p5_file, p7_file, merged_file, padding_bases, padding_quality):
-    """Merge the p5 and p7 reads from the input files into one read,
-    joined by padding bases.
-    """
-    print(f"Opening files:\n    {p5_file}\n    {p7_file}")
-    print(f"Writing to:\n    {merged_file}")
-    p5_reader = dinopy.FastqReader(p5_file)
-    p7_reader = dinopy.FastqReader(p7_file)
+# get and open input files from the calling snakemake rules input directive
+p5_file, p7_file = snakemake.input
+print(f"Opening files:\n    {p5_file}\n    {p7_file}", file=sys.stderr)
+print(f"Writing to:\n    {snakemake.output.merged}", file=sys.stderr)
+p5_reader = dinopy.FastqReader(p5_file)
+p7_reader = dinopy.FastqReader(p7_file)
 
-    if len(padding_quality) != 1:
-        print("Please specify a single Sanger Phred+33 quality value for "
-              "padding.\nExample: --padding-quality !")
-        sys.exit(1)
-    else:
-        padding_quality = padding_quality.encode()
+# check if the quality value for the join sequence is valid
+join_quality = snakemake.params.join_quality
+if len(join_quality) != 1:
+    print("Please specify a single Sanger Phred+33 quality value for "
+          "join_quality.", file=sys.stderr)
+    sys.exit(1)
+else:
+    join_quality = join_quality.encode()
 
-    padding_bases = padding_bases.encode()
-    padding_qvs = padding_quality * len(padding_bases)
-    with dinopy.FastqWriter(merged_file, force_overwrite=True) as writer:
-        for p5_read, p7_read in zip(p5_reader.reads(), p7_reader.reads()):
-            merged_seq = b"".join(
-                (p5_read.sequence, padding_bases, p7_read.sequence)
-            )
-            merged_qvs = b"".join(
-                (p5_read.quality, padding_qvs, p7_read.quality)
-            )
-            writer.write(merged_seq, p5_read.name, merged_qvs)
+# Assemble join sequence and quality values
+join_seq = snakemake.params.join_seq.encode()
+join_qvs = (snakemake.params.join_quality * len(join_seq)).encode()
 
-
-if __name__ == "__main__":
-    merge_mates()
+# join all reads
+with dinopy.FastqWriter(snakemake.output.merged, force_overwrite=True) as writer:
+    for p5_read, p7_read in zip(p5_reader.reads(), p7_reader.reads()):
+        merged_seq = b"".join(
+            (p5_read.sequence, join_seq, p7_read.sequence)
+        )
+        merged_qvs = b"".join(
+            (p5_read.quality, join_qvs, p7_read.quality)
+        )
+        writer.write(merged_seq, p5_read.name, merged_qvs)


### PR DESCRIPTION
As title.

Is there a more idiomatic way to redirect the output of a script called using the script directive in snakemake than [the hack I used?](https://github.com/koesterlab/rad-seq-stacks/compare/refactor_merge_script?expand=1#diff-30c9bfa971874012a213fefc47133886R9)