### PR TITLE
Additional output

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -51,6 +51,14 @@ params:
   gstacks: ""
   # command line parameters for process_radtags
   process_radtags: "--inline_null -q -r --barcode_dist_1 3 -D"
+  populations:
+    # Desired output formats for the stacks populations script.
+    # Possible values are vcf, genepop, fasta, phylip
+    output_types:
+      - vcf
+      - genepop
+      - fasta
+      - phylip
   kraken:
     # Refer to kraken DB folder, see https://ccb.jhu.edu/software/kraken.
     # Kraken is used to classify reads for possible contaminations.

--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 import zlib
+import sys
 
 configfile: "config.yaml"
 
@@ -16,17 +17,35 @@ if kraken_db:
                              "plots/{unit}.classification.svg"],
                             unit=units.id)
 
+def pop_suffixes():
+    """Map input file types of the stacks populations script
+    to the file suffixes they generate.
+    """
+    pop_file_suffixes = {
+        "fasta": ["samples-raw.fa"],
+        "genepop": ["snps.genepop", "haps.genepop"],
+        "vcf": ["snps.vcf", "haps.vcf"],
+        "phylip": ["fixed.phylip", "fixed.phylip.log"],
+    }
+    suffixes = []
+    for f_type in config["params"]["populations"]["output_types"]:
+        try:
+            suffixes.extend(pop_file_suffixes[f_type])
+        except KeyError:
+            print(f"Invalid output type {f_type} for populations. Should be one of {pop_file_suffixes.keys()}.", file=sys.stderr)
+    if suffixes:
+        return suffixes
+    else:
+        print(f"No valid output files specified for populations.", file=sys.stderr)
+        sys.exit(1)
+
 
 rule all:
     input:
-        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.snps.vcf",
-               p=config["params"]["stacks"]),
-        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.snps.genepop",
-               p=config["params"]["stacks"]),
-        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.samples-raw.fa",
-               p=config["params"]["stacks"]),
-        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.fixed.phylip",
-               p=config["params"]["stacks"]),
+        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.{e}",
+               p=config["params"]["stacks"],
+               e=pop_suffixes(),
+        ),
         kraken_targets
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -21,6 +21,12 @@ rule all:
     input:
         expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.snps.vcf",
                p=config["params"]["stacks"]),
+        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.snps.genepop",
+               p=config["params"]["stacks"]),
+        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.samples-raw.fa",
+               p=config["params"]["stacks"]),
+        expand("calls/n={p[max_locus_mm]}.M={p[max_individual_mm]}.m={p[min_reads]}.populations.fixed.phylip",
+               p=config["params"]["stacks"]),
         kraken_targets
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,15 @@ params:
   # command line parameters for process_radtags in addition to:
   # -f --renz_1 -b -o -y and -i, which are handled by snakemake
   process_radtags: "--inline_null -q -r --barcode_dist_1 3 -D"
+  # Additional parameters for the populations script.
+  populations:
+    # Desired output formats for the stacks populations script.
+    # Possible values are vcf, genepop, fasta, phylip
+    output_types:
+      - vcf
+      - genepop
+      - fasta
+      - phylip
   kraken:
     # Refer to kraken DB folder, see https://ccb.jhu.edu/software/kraken.
     # Kraken is used to classify reads for possible contaminations.

--- a/rules/stacks.smk
+++ b/rules/stacks.smk
@@ -143,6 +143,9 @@ rule populations:
         report(expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.vcf", type=["snps", "haps"]),
                caption="../report/calls.rst",
                category="Populations"),
+        expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.genepop", type=["snps", "haps"]),
+        expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.fixed.phylip{type}", type=["", ".log"]),
+        "calls/n={max_locus_mm}.M={max_individual_mm}.m={min_reads}.populations.samples-raw.fa",
         report(expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.tsv", type=["sumstats_summary", "sumstats"]),
                caption="../report/sumstats.rst",
                category="Populations"),
@@ -160,5 +163,5 @@ rule populations:
     shell:
         "mkdir -p {params.outdir}; "
         "populations -t {threads} -P {params.gstacks_dir} "
-        "-O {params.outdir} --vcf > {log}; "
+        "-O {params.outdir} --vcf --genepop --phylip --fasta > {log}; "
         "rename 's!{params.outdir}/!{params.outdir}.!' {params.outdir}/* "

--- a/rules/stacks.smk
+++ b/rules/stacks.smk
@@ -140,12 +140,8 @@ rule populations:
     input:
         "stacks/n={max_locus_mm}.M={max_individual_mm}.m={min_reads}/catalog.calls"
     output:
-        report(expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.vcf", type=["snps", "haps"]),
-               caption="../report/calls.rst",
-               category="Populations"),
-        expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.genepop", type=["snps", "haps"]),
-        expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.fixed.phylip{type}", type=["", ".log"]),
-        "calls/n={max_locus_mm}.M={max_individual_mm}.m={min_reads}.populations.samples-raw.fa",
+        expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{e}",
+               e=pop_suffixes()),
         report(expand("calls/n={{max_locus_mm}}.M={{max_individual_mm}}.m={{min_reads}}.populations.{type}.tsv", type=["sumstats_summary", "sumstats"]),
                caption="../report/sumstats.rst",
                category="Populations"),
@@ -154,7 +150,8 @@ rule populations:
                category="Populations"),
     params:
         outdir="calls/n={max_locus_mm}.M={max_individual_mm}.m={min_reads}",
-        gstacks_dir=lambda w, input: os.path.dirname(input[0])
+        gstacks_dir=lambda w, input: os.path.dirname(input[0]),
+        output_types=[f"--{t}" for t in config["params"]["populations"]["output_types"]],
     conda:
         "../envs/stacks.yaml"
     threads: 8
@@ -163,5 +160,5 @@ rule populations:
     shell:
         "mkdir -p {params.outdir}; "
         "populations -t {threads} -P {params.gstacks_dir} "
-        "-O {params.outdir} --vcf --genepop --phylip --fasta > {log}; "
+        "-O {params.outdir} {params.output_types} > {log}; "
         "rename 's!{params.outdir}/!{params.outdir}.!' {params.outdir}/* "


### PR DESCRIPTION
This PR adds support for different output types for the stacks populations script.

The desired file types can be selected using the corresponding parameter in the config.yaml. Input files for rule all and output files for rule populations are programmatically generated using the `pop_suffixes()` function in the main Snakemake file. To alert users of invalid output file types for this parameter, I added some output via stderr in said function.